### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Take a look at [Fonticons search page] (http://designjockey.github.io/material-d
 
 There are multiple css files included in the `styles` folder. The `mdfi.css` file includes the `mdfi` font with icons from all the categories, while other category specific css files `mdfi_{category}.css` contain category specific icons with font name `mdfi-{category}`.
 
-##Using the Fonticons
+## Using the Fonticons
 
 For using the icons follow the below instructions. The icon classes are named using the `mdfi_{category}_{original_icon_name}` convention. Refer to [Fonticons search page] (http://designjockey.github.io/material-design-fonticons/) for class names.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
